### PR TITLE
Inverse logic for forwarding execution of messages

### DIFF
--- a/contracts/upgradeable_contracts/modules/forwarding_rules/MultiTokenForwardingRulesConnector.sol
+++ b/contracts/upgradeable_contracts/modules/forwarding_rules/MultiTokenForwardingRulesConnector.sol
@@ -50,6 +50,7 @@ contract MultiTokenForwardingRulesConnector is Ownable {
         address _receiver
     ) internal view returns (bool) {
         MultiTokenForwardingRulesManager manager = forwardingRulesManager();
-        return address(manager) == address(0) || manager.destinationLane(_token, _sender, _receiver) >= 0;
+        // If the manager is defined the default behavior is to use manual lane
+        return address(manager) == address(0) || manager.destinationLane(_token, _sender, _receiver) > 0;
     }
 }

--- a/contracts/upgradeable_contracts/modules/forwarding_rules/MultiTokenForwardingRulesManager.sol
+++ b/contracts/upgradeable_contracts/modules/forwarding_rules/MultiTokenForwardingRulesManager.sol
@@ -34,7 +34,7 @@ contract MultiTokenForwardingRulesManager is OwnableModule {
     ) public view returns (int256) {
         int256 defaultLane = forwardingRule[_token][ANY_ADDRESS][ANY_ADDRESS]; // specific token for all senders and receivers
         int256 lane;
-        if (defaultLane < 0) {
+        if (defaultLane > 0) {
             lane = forwardingRule[_token][_sender][ANY_ADDRESS]; // specific token for specific sender
             if (lane != 0) return lane;
             lane = forwardingRule[_token][ANY_ADDRESS][_receiver]; // specific token for specific receiver
@@ -50,19 +50,19 @@ contract MultiTokenForwardingRulesManager is OwnableModule {
      * Updates the forwarding rule for bridging specific token.
      * Only owner can call this method.
      * @param _token address of the token contract on the foreign side.
-     * @param _enable true, if bridge operations for a given token should be forwarded to the manual lane.
+     * @param _enable true, if bridge operations for a given token should be forwarded to the oracle-driven lane.
      */
     function setTokenForwardingRule(address _token, bool _enable) external {
         require(_token != ANY_ADDRESS);
-        _setForwardingRule(_token, ANY_ADDRESS, ANY_ADDRESS, _enable ? int256(-1) : int256(0));
+        _setForwardingRule(_token, ANY_ADDRESS, ANY_ADDRESS, _enable ? int256(1) : int256(0));
     }
 
     /**
-     * Allows a particular address to send bridge requests to the oracle-driven lane for a particular token.
+     * Allows a particular address to send bridge requests to the manual lane for a particular token.
      * Only owner can call this method.
      * @param _token address of the token contract on the foreign side.
      * @param _sender address of the tokens sender on the home side of the bridge.
-     * @param _enable true, if bridge operations for a given token and sender should be forwarded to the oracle-driven lane.
+     * @param _enable true, if bridge operations for a given token and sender should be forwarded to the manual lane.
      */
     function setSenderExceptionForTokenForwardingRule(
         address _token,
@@ -71,15 +71,15 @@ contract MultiTokenForwardingRulesManager is OwnableModule {
     ) external {
         require(_token != ANY_ADDRESS);
         require(_sender != ANY_ADDRESS);
-        _setForwardingRule(_token, _sender, ANY_ADDRESS, _enable ? int256(1) : int256(0));
+        _setForwardingRule(_token, _sender, ANY_ADDRESS, _enable ? int256(-1) : int256(0));
     }
 
     /**
-     * Allows a particular address to receive bridged tokens from the oracle-driven lane for a particular token.
+     * Allows a particular address to receive bridged tokens from the manual lane for a particular token.
      * Only owner can call this method.
      * @param _token address of the token contract on the foreign side.
      * @param _receiver address of the tokens receiver on the foreign side of the bridge.
-     * @param _enable true, if bridge operations for a given token and receiver should be forwarded to the oracle-driven lane.
+     * @param _enable true, if bridge operations for a given token and receiver should be forwarded to the manual lane.
      */
     function setReceiverExceptionForTokenForwardingRule(
         address _token,
@@ -88,29 +88,29 @@ contract MultiTokenForwardingRulesManager is OwnableModule {
     ) external {
         require(_token != ANY_ADDRESS);
         require(_receiver != ANY_ADDRESS);
-        _setForwardingRule(_token, ANY_ADDRESS, _receiver, _enable ? int256(1) : int256(0));
+        _setForwardingRule(_token, ANY_ADDRESS, _receiver, _enable ? int256(-1) : int256(0));
     }
 
     /**
      * Updates the forwarding rule for the specific sender.
      * Only owner can call this method.
      * @param _sender address of the tokens sender on the home side.
-     * @param _enable true, if all bridge operations from a given sender should be forwarded to the manual lane.
+     * @param _enable true, if all bridge operations from a given sender should be forwarded to the oracle-driven lane.
      */
     function setSenderForwardingRule(address _sender, bool _enable) external {
         require(_sender != ANY_ADDRESS);
-        _setForwardingRule(ANY_ADDRESS, _sender, ANY_ADDRESS, _enable ? int256(-1) : int256(0));
+        _setForwardingRule(ANY_ADDRESS, _sender, ANY_ADDRESS, _enable ? int256(1) : int256(0));
     }
 
     /**
      * Updates the forwarding rule for the specific receiver.
      * Only owner can call this method.
      * @param _receiver address of the tokens receiver on the foreign side.
-     * @param _enable true, if all bridge operations to a given receiver should be forwarded to the manual lane.
+     * @param _enable true, if all bridge operations to a given receiver should be forwarded to the oracle-driven lane.
      */
     function setReceiverForwardingRule(address _receiver, bool _enable) external {
         require(_receiver != ANY_ADDRESS);
-        _setForwardingRule(ANY_ADDRESS, ANY_ADDRESS, _receiver, _enable ? int256(-1) : int256(0));
+        _setForwardingRule(ANY_ADDRESS, ANY_ADDRESS, _receiver, _enable ? int256(1) : int256(0));
     }
 
     /**

--- a/test/omnibridge/common.test.js
+++ b/test/omnibridge/common.test.js
@@ -2187,15 +2187,15 @@ function runTests(accounts, isHome) {
         await manager.setTokenForwardingRule(token.address, true, { from: user }).should.be.rejected
         await manager.setTokenForwardingRule(token.address, true, { from: owner }).should.be.fulfilled
 
-        expect(await manager.destinationLane(token.address, user, user2)).to.be.bignumber.equal('-1')
+        expect(await manager.destinationLane(token.address, user, user2)).to.be.bignumber.equal('1')
 
         await manager.setSenderExceptionForTokenForwardingRule(token.address, user, true, { from: user }).should.be
           .rejected
         await manager.setSenderExceptionForTokenForwardingRule(token.address, user, true, { from: owner }).should.be
           .fulfilled
 
-        expect(await manager.destinationLane(token.address, user, user2)).to.be.bignumber.equal('1')
-        expect(await manager.destinationLane(token.address, user2, user2)).to.be.bignumber.equal('-1')
+        expect(await manager.destinationLane(token.address, user, user2)).to.be.bignumber.equal('-1')
+        expect(await manager.destinationLane(token.address, user2, user2)).to.be.bignumber.equal('1')
 
         await manager.setSenderExceptionForTokenForwardingRule(token.address, user, false, { from: owner }).should.be
           .fulfilled
@@ -2204,8 +2204,8 @@ function runTests(accounts, isHome) {
         await manager.setReceiverExceptionForTokenForwardingRule(token.address, user, true, { from: owner }).should.be
           .fulfilled
 
-        expect(await manager.destinationLane(token.address, user, user)).to.be.bignumber.equal('1')
-        expect(await manager.destinationLane(token.address, user, user2)).to.be.bignumber.equal('-1')
+        expect(await manager.destinationLane(token.address, user, user)).to.be.bignumber.equal('-1')
+        expect(await manager.destinationLane(token.address, user, user2)).to.be.bignumber.equal('1')
 
         await manager.setTokenForwardingRule(token.address, false, { from: owner }).should.be.fulfilled
 
@@ -2214,12 +2214,12 @@ function runTests(accounts, isHome) {
         await manager.setSenderForwardingRule(user2, true, { from: user }).should.be.rejected
         await manager.setSenderForwardingRule(user2, true, { from: owner }).should.be.fulfilled
 
-        expect(await manager.destinationLane(token.address, user2, user2)).to.be.bignumber.equal('-1')
+        expect(await manager.destinationLane(token.address, user2, user2)).to.be.bignumber.equal('1')
 
         await manager.setReceiverForwardingRule(user2, true, { from: user }).should.be.rejected
         await manager.setReceiverForwardingRule(user2, true, { from: owner }).should.be.fulfilled
 
-        expect(await manager.destinationLane(token.address, user, user2)).to.be.bignumber.equal('-1')
+        expect(await manager.destinationLane(token.address, user, user2)).to.be.bignumber.equal('1')
       })
 
       it('should send a message to the manual lane', async () => {

--- a/test/omnibridge/common.test.js
+++ b/test/omnibridge/common.test.js
@@ -2222,7 +2222,7 @@ function runTests(accounts, isHome) {
         expect(await manager.destinationLane(token.address, user, user2)).to.be.bignumber.equal('1')
       })
 
-      it('should send a message to the manual lane', async () => {
+      it('should send a message to the oracle-driven lane', async () => {
         await initialize().should.be.fulfilled
         await token.mint(user, ether('10'), { from: owner }).should.be.fulfilled
         const args = [otherSideToken1, 'Test', 'TST', 18, user, value]
@@ -2244,10 +2244,10 @@ function runTests(accounts, isHome) {
         expect(events.length).to.be.equal(6)
         expect(events[0].returnValues.dataType).to.be.bignumber.equal('0')
         expect(events[1].returnValues.dataType).to.be.bignumber.equal('0')
-        expect(events[2].returnValues.dataType).to.be.bignumber.equal('0')
-        expect(events[3].returnValues.dataType).to.be.bignumber.equal('0')
-        expect(events[4].returnValues.dataType).to.be.bignumber.equal('128')
-        expect(events[5].returnValues.dataType).to.be.bignumber.equal('128')
+        expect(events[2].returnValues.dataType).to.be.bignumber.equal('128')
+        expect(events[3].returnValues.dataType).to.be.bignumber.equal('128')
+        expect(events[4].returnValues.dataType).to.be.bignumber.equal('0')
+        expect(events[5].returnValues.dataType).to.be.bignumber.equal('0')
       })
     })
   }


### PR DESCRIPTION
As per usage of the OmniBridge it was found that the typical configuration is to
1. Add the OmniBridge contract to the allowance list on the oracles.
2. Configure only specific tokens to use the oracle-driven lane as so transfers for the rest of tokens must be executed manually on the Foreign side.

Such configuration requires inverse of the logic on the forwarding rules manager:
  - the default lane is the manual execution
  - setting of a forwarding rule for a token corresponds to sending token transfers to the oracle-driven lane
  - adding exceptions with a sender/recipient for the token, force activates the manual lane
  - setting of a forwarding rule for a sender/recipient corresponds to sending tokens to the oracle-driven lane