### PR TITLE
Bump package and contracts interfaces version prior to 1.1.0-rc1

### DIFF
--- a/contracts/upgradeable_contracts/components/common/OmnibridgeInfo.sol
+++ b/contracts/upgradeable_contracts/components/common/OmnibridgeInfo.sol
@@ -31,7 +31,7 @@ contract OmnibridgeInfo is VersionableBridge {
             uint64 patch
         )
     {
-        return (3, 1, 0);
+        return (3, 2, 0);
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omnibridge",
-  "version": "1.1.0-rc0",
+  "version": "1.1.0-rc1",
   "description": "Omnibridge AMB extension",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The version has been updated since there were changes in the logic of the mediator contract made under #50.