### PR TITLE
Small gas optimization after EIP2929

### DIFF
--- a/contracts/upgradeable_contracts/ForeignOmnibridge.sol
+++ b/contracts/upgradeable_contracts/ForeignOmnibridge.sol
@@ -157,7 +157,10 @@ contract ForeignOmnibridge is BasicOmnibridge, GasLimitManager, InterestConnecto
             }
 
             IInterestImplementation impl = interestImplementation(_token);
-            if (Address.isContract(address(impl))) {
+            // can be used instead of Address.isContract(address(impl)),
+            // since _setInterestImplementation guarantees that impl is either a contract or zero address
+            // and interest implementation does not contain any selfdestruct opcode
+            if (address(impl) != address(0)) {
                 uint256 availableBalance = balance.sub(impl.investedAmount(_token));
                 if (_value > availableBalance) {
                     impl.withdraw(_token, (_value - availableBalance).add(minCashThreshold(_token)));


### PR DESCRIPTION
For each token an `IInterestImplementation` can be chosen inside the `ForeignOmnibridge`. When a token is handled this is checked as follows:

https://github.com/omni/omnibridge/blob/d22cd509ac853f10c19c1e8e3ad07f02171a8c5f/contracts/upgradeable_contracts/ForeignOmnibridge.sol#L159-L160

In case no `IInterestImplementation` has been registered the `impl` value will be the zero address. Querying the existence of a contract at this address requires caching the account (due to EIP-2929) and hence incurs non-trivial gas costs. This could be avoided if the check would be modified to first handle the zero address.