### PR TITLE
Fix interest impl comments

### DIFF
--- a/contracts/upgradeable_contracts/modules/interest/AAVEInterestERC20.sol
+++ b/contracts/upgradeable_contracts/modules/interest/AAVEInterestERC20.sol
@@ -60,7 +60,7 @@ contract AAVEInterestERC20 is IInterestImplementation, MediatorOwnableModule {
      * @dev Enables support for interest earning through a specific aToken.
      * @param _token address of the token contract for which to enable interest.
      * @param _dust small amount of underlying tokens that cannot be paid as an interest. Accounts for possible truncation errors.
-     * @param _interestReceiver address of the interest receiver for underlying token and associated COMP tokens.
+     * @param _interestReceiver address of the interest receiver for underlying token.
      * @param _minInterestPaid min amount of underlying tokens to be paid as an interest.
      */
     function enableInterestToken(
@@ -112,7 +112,7 @@ contract AAVEInterestERC20 is IInterestImplementation, MediatorOwnableModule {
     }
 
     /**
-     * @dev Withdraws at least the given amount of tokens from the AAVE protocol.
+     * @dev Withdraws at least min(_amount, investedAmount) of tokens from the AAVE protocol.
      * Only Omnibridge contract is allowed to call this method.
      * Converts aTOKENs into _amount of TOKENs.
      * @param _token address of the invested token contract.

--- a/contracts/upgradeable_contracts/modules/interest/CompoundInterestERC20.sol
+++ b/contracts/upgradeable_contracts/modules/interest/CompoundInterestERC20.sol
@@ -65,7 +65,7 @@ contract CompoundInterestERC20 is IInterestImplementation, MediatorOwnableModule
      * @dev Enables support for interest earning through specific cToken.
      * @param _cToken address of the cToken contract. Underlying token address is derived from this contract.
      * @param _dust small amount of underlying tokens that cannot be paid as an interest. Accounts for possible truncation errors.
-     * @param _interestReceiver address of the interest receiver for underlying token and associated COMP tokens.
+     * @param _interestReceiver address of the interest receiver for underlying token.
      * @param _minInterestPaid min amount of underlying tokens to be paid as an interest.
      */
     function enableInterestToken(
@@ -129,7 +129,7 @@ contract CompoundInterestERC20 is IInterestImplementation, MediatorOwnableModule
     }
 
     /**
-     * @dev Withdraws at least the given amount of tokens from the Compound protocol.
+     * @dev Withdraws at least min(_amount, investedAmount) of tokens from the Compound protocol.
      * Only Omnibridge contract is allowed to call this method.
      * Converts X cTOKENs into _amount of TOKENs.
      * @param _token address of the invested token contract.


### PR DESCRIPTION
The documentation on the withdraw function in CompoundInterestERC20.sol and AAVEInterestERC20.sol reads:

https://github.com/omni/omnibridge/blob/d22cd509ac853f10c19c1e8e3ad07f02171a8c5f/contracts/upgradeable_contracts/modules/interest/AAVEInterestERC20.sol#L114-L127

https://github.com/omni/omnibridge/blob/d22cd509ac853f10c19c1e8e3ad07f02171a8c5f/contracts/upgradeable_contracts/modules/interest/CompoundInterestERC20.sol#L131-L144

However, if the `_amount` specified is greater than the amount invested, only the amount invested will actually be redeemed. Therefore, an amount of tokens less than the specified `_amount` can be withdrawn, contradicting the documentation.

Additionally, the comment on the `_enableInterestToken` function in CompoundInterestERC20.sol reads:

https://github.com/omni/omnibridge/blob/d22cd509ac853f10c19c1e8e3ad07f02171a8c5f/contracts/upgradeable_contracts/modules/interest/CompoundInterestERC20.sol#L68

However, the account that receives COMP tokens is compReceiver, which is set in the constructor.

Lastly, the comment on the `_enableInterestToken` function in AAVEInterestERC20.sol also mentions COMP tokens even though no COMP tokens will be handled.
