### PR TITLE
Lazy AAVE token balance query

### DIFF
--- a/contracts/upgradeable_contracts/modules/interest/AAVEInterestERC20.sol
+++ b/contracts/upgradeable_contracts/modules/interest/AAVEInterestERC20.sol
@@ -163,11 +163,10 @@ contract AAVEInterestERC20 is IInterestImplementation, MediatorOwnableModule {
         InterestParams storage params = interestParams[_token];
         IAToken aToken = params.aToken;
 
-        uint256 aTokenBalance = aToken.balanceOf(address(this));
+        uint256 aTokenBalance = 0;
         // try to redeem all aTokens
-        try lendingPool().withdraw(_token, aTokenBalance, mediator) {
-            aTokenBalance = 0;
-        } catch {
+        try lendingPool().withdraw(_token, uint256(-1), mediator) {} catch {
+            aTokenBalance = aToken.balanceOf(address(this));
             aToken.transfer(mediator, aTokenBalance);
         }
 

--- a/contracts/upgradeable_contracts/modules/interest/AAVEInterestERC20.sol
+++ b/contracts/upgradeable_contracts/modules/interest/AAVEInterestERC20.sol
@@ -165,6 +165,8 @@ contract AAVEInterestERC20 is IInterestImplementation, MediatorOwnableModule {
 
         uint256 aTokenBalance = 0;
         // try to redeem all aTokens
+        // it is safe to specify uint256(-1) as max amount of redeemed tokens
+        // since the withdraw method of the pool contract will return the entire balance
         try lendingPool().withdraw(_token, uint256(-1), mediator) {} catch {
             aTokenBalance = aToken.balanceOf(address(this));
             aToken.transfer(mediator, aTokenBalance);


### PR DESCRIPTION
In the function `forceDisable` in AAVEInterestERC20.sol, aToken.balanceOf is queried in order to withdraw all invested funds:

https://github.com/omni/omnibridge/blob/d22cd509ac853f10c19c1e8e3ad07f02171a8c5f/contracts/upgradeable_contracts/modules/interest/AAVEInterestERC20.sol#L166-L172

This balance query is not necessary, because according to the documentation of `LendingPool.withdraw()`, one can set the balance to `type(uint256).max (or uint256(-1))` to withdraw the entire balance. In case the withdraw fails, the balance could be queried inside the catch block in order to transfer the aTokens to the mediator.
```
/**
 * . . .
 * @param amount The underlying amount to be withdrawn
 *   - Send the value type(uint256).max in order to withdraw the whole aToken balance
 * . . .
**/
function withdraw(address asset, uint256 amount, address to) external returns (uint256);
```