### PR TITLE
Use single delete

### DIFF
--- a/contracts/upgradeable_contracts/modules/interest/AAVEInterestERC20.sol
+++ b/contracts/upgradeable_contracts/modules/interest/AAVEInterestERC20.sol
@@ -176,11 +176,7 @@ contract AAVEInterestERC20 is IInterestImplementation, MediatorOwnableModule {
 
         emit ForceDisable(_token, balance, aTokenBalance, params.investedAmount);
 
-        delete params.aToken;
-        delete params.dust;
-        delete params.investedAmount;
-        delete params.minInterestPaid;
-        delete params.interestReceiver;
+        delete interestParams[_token];
     }
 
     /**

--- a/contracts/upgradeable_contracts/modules/interest/CompoundInterestERC20.sol
+++ b/contracts/upgradeable_contracts/modules/interest/CompoundInterestERC20.sol
@@ -217,11 +217,7 @@ contract CompoundInterestERC20 is IInterestImplementation, MediatorOwnableModule
 
         emit ForceDisable(_token, balance, cTokenBalance, params.investedAmount);
 
-        delete params.cToken;
-        delete params.dust;
-        delete params.investedAmount;
-        delete params.minInterestPaid;
-        delete params.interestReceiver;
+        delete interestParams[_token];
     }
 
     /**


### PR DESCRIPTION
In the function `forceDisable` in AAVEInterestERC20.sol and CompoundInterestERC20.sol, an instance of InterestParams is deleted.

https://github.com/omni/omnibridge/blob/d22cd509ac853f10c19c1e8e3ad07f02171a8c5f/contracts/upgradeable_contracts/modules/interest/AAVEInterestERC20.sol#L179-L183

Because all fields of the struct are deleted, these delete statements can be combined into:

```
delete interestParams[_token];
```