### PR TITLE
Fix minor issues

### DIFF
--- a/contracts/interfaces/IInterestImplementation.sol
+++ b/contracts/interfaces/IInterestImplementation.sol
@@ -3,6 +3,13 @@ pragma solidity 0.7.5;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface IInterestImplementation {
+    event InterestEnabled(address indexed token, address xToken);
+    event InterestDustUpdated(address indexed token, uint96 dust);
+    event InterestReceiverUpdated(address indexed token, address receiver);
+    event MinInterestPaidUpdated(address indexed token, uint256 amount);
+    event PaidInterest(address indexed token, address to, uint256 value);
+    event ForceDisable(address indexed token, uint256 tokensAmount, uint256 xTokensAmount, uint256 investedAmount);
+
     function isInterestSupported(address _token) external view returns (bool);
 
     function invest(address _token, uint256 _amount) external;

--- a/contracts/upgradeable_contracts/modules/interest/AAVEInterestERC20.sol
+++ b/contracts/upgradeable_contracts/modules/interest/AAVEInterestERC20.sol
@@ -16,9 +16,6 @@ import "../MediatorOwnableModule.sol";
 contract AAVEInterestERC20 is IInterestImplementation, MediatorOwnableModule {
     using SafeMath for uint256;
 
-    event PaidInterest(address indexed token, address to, uint256 value);
-    event ForceDisable(address token, uint256 tokensAmount, uint256 aTokensAmount, uint256 investedAmount);
-
     struct InterestParams {
         IAToken aToken;
         uint96 dust;
@@ -78,6 +75,11 @@ contract AAVEInterestERC20 is IInterestImplementation, MediatorOwnableModule {
         interestParams[_token] = InterestParams(aToken, _dust, 0, _interestReceiver, _minInterestPaid);
 
         IERC20(_token).approve(address(lendingPool()), uint256(-1));
+
+        emit InterestEnabled(_token, address(aToken));
+        emit InterestDustUpdated(_token, _dust);
+        emit InterestReceiverUpdated(_token, _interestReceiver);
+        emit MinInterestPaidUpdated(_token, _minInterestPaid);
     }
 
     /**
@@ -173,6 +175,7 @@ contract AAVEInterestERC20 is IInterestImplementation, MediatorOwnableModule {
 
         uint256 balance = IERC20(_token).balanceOf(address(this));
         IERC20(_token).transfer(mediator, balance);
+        IERC20(_token).approve(address(lendingPool()), 0);
 
         emit ForceDisable(_token, balance, aTokenBalance, params.investedAmount);
 
@@ -191,6 +194,7 @@ contract AAVEInterestERC20 is IInterestImplementation, MediatorOwnableModule {
      */
     function setDust(address _token, uint96 _dust) external onlyOwner {
         interestParams[_token].dust = _dust;
+        emit InterestDustUpdated(_token, _dust);
     }
 
     /**
@@ -202,6 +206,7 @@ contract AAVEInterestERC20 is IInterestImplementation, MediatorOwnableModule {
      */
     function setInterestReceiver(address _token, address _receiver) external onlyOwner {
         interestParams[_token].interestReceiver = _receiver;
+        emit InterestReceiverUpdated(_token, _receiver);
     }
 
     /**
@@ -212,6 +217,7 @@ contract AAVEInterestERC20 is IInterestImplementation, MediatorOwnableModule {
      */
     function setMinInterestPaid(address _token, uint256 _minInterestPaid) external onlyOwner {
         interestParams[_token].minInterestPaid = _minInterestPaid;
+        emit MinInterestPaidUpdated(_token, _minInterestPaid);
     }
 
     /**

--- a/contracts/upgradeable_contracts/modules/interest/CompoundInterestERC20.sol
+++ b/contracts/upgradeable_contracts/modules/interest/CompoundInterestERC20.sol
@@ -16,9 +16,6 @@ import "../MediatorOwnableModule.sol";
 contract CompoundInterestERC20 is IInterestImplementation, MediatorOwnableModule {
     using SafeMath for uint256;
 
-    event PaidInterest(address indexed token, address to, uint256 value);
-    event ForceDisable(address token, uint256 tokensAmount, uint256 cTokensAmount, uint256 investedAmount);
-
     uint256 internal constant SUCCESS = 0;
 
     struct InterestParams {
@@ -81,6 +78,11 @@ contract CompoundInterestERC20 is IInterestImplementation, MediatorOwnableModule
         interestParams[token] = InterestParams(_cToken, _dust, 0, _interestReceiver, _minInterestPaid);
 
         IERC20(token).approve(address(_cToken), uint256(-1));
+
+        emit InterestEnabled(token, address(_cToken));
+        emit InterestDustUpdated(token, _dust);
+        emit InterestReceiverUpdated(token, _interestReceiver);
+        emit MinInterestPaidUpdated(token, _minInterestPaid);
     }
 
     /**
@@ -214,6 +216,7 @@ contract CompoundInterestERC20 is IInterestImplementation, MediatorOwnableModule
 
         uint256 balance = IERC20(_token).balanceOf(address(this));
         IERC20(_token).transfer(mediator, balance);
+        IERC20(_token).approve(address(cToken), 0);
 
         emit ForceDisable(_token, balance, cTokenBalance, params.investedAmount);
 
@@ -232,6 +235,7 @@ contract CompoundInterestERC20 is IInterestImplementation, MediatorOwnableModule
      */
     function setDust(address _token, uint96 _dust) external onlyOwner {
         interestParams[_token].dust = _dust;
+        emit InterestDustUpdated(_token, _dust);
     }
 
     /**
@@ -243,6 +247,7 @@ contract CompoundInterestERC20 is IInterestImplementation, MediatorOwnableModule
      */
     function setInterestReceiver(address _token, address _receiver) external onlyOwner {
         interestParams[_token].interestReceiver = _receiver;
+        emit InterestReceiverUpdated(_token, _receiver);
     }
 
     /**
@@ -253,6 +258,7 @@ contract CompoundInterestERC20 is IInterestImplementation, MediatorOwnableModule
      */
     function setMinInterestPaid(address _token, uint256 _minInterestPaid) external onlyOwner {
         interestParams[_token].minInterestPaid = _minInterestPaid;
+        emit MinInterestPaidUpdated(_token, _minInterestPaid);
     }
 
     /**
@@ -262,6 +268,7 @@ contract CompoundInterestERC20 is IInterestImplementation, MediatorOwnableModule
      */
     function setMinCompPaid(uint256 _minCompPaid) external onlyOwner {
         minCompPaid = _minCompPaid;
+        emit MinInterestPaidUpdated(address(compToken()), _minCompPaid);
     }
 
     /**
@@ -272,6 +279,7 @@ contract CompoundInterestERC20 is IInterestImplementation, MediatorOwnableModule
      */
     function setCompReceiver(address _receiver) external onlyOwner {
         compReceiver = _receiver;
+        emit InterestReceiverUpdated(address(compToken()), _receiver);
     }
 
     /**


### PR DESCRIPTION
## 1
The `CompoundInterestERC20` and `AAVEInterestERC20` contracts do not emit any events when values in interestParams are changed or initialized first time. List of such functions:
- `setMinInterestPaid`
- `setInterestReceiver`
- `setDust`
- `enableInterestToken`
- `setMinCompPaid` in `CompoundInterestERC20`
- `setCompReceiver` in `CompoundInterestERC20`

To make monitoring easier it can be helpful to add such events.

## 2

When `enableInterestToken` is called within the `CompoundInterestERC20` and `AAVEInterestERC20` contracts, the respective interest implementation approves the lending pool for the maximum amount of tokens. When `forceDisable` is called, this allowance is not revoked.

## 3

Both `CompoundInterestERC20` and `AAVEInterestERC20` define the following events:

https://github.com/omni/omnibridge/blob/d22cd509ac853f10c19c1e8e3ad07f02171a8c5f/contracts/upgradeable_contracts/modules/interest/AAVEInterestERC20.sol#L19-L20

https://github.com/omni/omnibridge/blob/d22cd509ac853f10c19c1e8e3ad07f02171a8c5f/contracts/upgradeable_contracts/modules/interest/CompoundInterestERC20.sol#L19-L20

Since they both also implement `IInterestImplementation` interface, such events can be defined in