### PR TITLE
Use SafeERC20 in interest implementations

### DIFF
--- a/contracts/upgradeable_contracts/components/common/InterestConnector.sol
+++ b/contracts/upgradeable_contracts/components/common/InterestConnector.sol
@@ -1,6 +1,7 @@
 pragma solidity 0.7.5;
 
 import "@openzeppelin/contracts/utils/Address.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "../../Ownable.sol";
 import "../../../interfaces/IInterestReceiver.sol";
@@ -13,6 +14,7 @@ import "../native/MediatorBalanceStorage.sol";
  */
 contract InterestConnector is Ownable, MediatorBalanceStorage {
     using SafeMath for uint256;
+    using SafeERC20 for IERC20;
 
     /**
      * @dev Tells address of the interest earning implementation for the specific token contract.
@@ -86,7 +88,7 @@ contract InterestConnector is Ownable, MediatorBalanceStorage {
         require(balance > minCash);
         uint256 amount = balance - minCash;
 
-        IERC20(_token).transfer(address(impl), amount);
+        IERC20(_token).safeTransfer(address(impl), amount);
         impl.invest(_token, amount);
     }
 

--- a/contracts/upgradeable_contracts/modules/interest/AAVEInterestERC20.sol
+++ b/contracts/upgradeable_contracts/modules/interest/AAVEInterestERC20.sol
@@ -14,6 +14,8 @@ import "./BaseInterestERC20.sol";
  */
 contract AAVEInterestERC20 is BaseInterestERC20, MediatorOwnableModule {
     using SafeMath for uint256;
+    using SafeERC20 for IERC20;
+    using SafeERC20 for IAToken;
 
     struct InterestParams {
         IAToken aToken;
@@ -124,7 +126,7 @@ contract AAVEInterestERC20 is BaseInterestERC20, MediatorOwnableModule {
         uint256 invested = params.investedAmount;
         uint256 redeemed = _safeWithdraw(_token, _amount > invested ? invested : _amount);
         params.investedAmount = redeemed > invested ? 0 : invested - redeemed;
-        IERC20(_token).transfer(mediator, redeemed);
+        IERC20(_token).safeTransfer(mediator, redeemed);
     }
 
     /**
@@ -170,11 +172,11 @@ contract AAVEInterestERC20 is BaseInterestERC20, MediatorOwnableModule {
         // since the withdraw method of the pool contract will return the entire balance
         try lendingPool().withdraw(_token, uint256(-1), mediator) {} catch {
             aTokenBalance = aToken.balanceOf(address(this));
-            aToken.transfer(mediator, aTokenBalance);
+            aToken.safeTransfer(mediator, aTokenBalance);
         }
 
         uint256 balance = IERC20(_token).balanceOf(address(this));
-        IERC20(_token).transfer(mediator, balance);
+        IERC20(_token).safeTransfer(mediator, balance);
         IERC20(_token).approve(address(lendingPool()), 0);
 
         emit ForceDisable(_token, balance, aTokenBalance, params.investedAmount);

--- a/contracts/upgradeable_contracts/modules/interest/BaseInterestERC20.sol
+++ b/contracts/upgradeable_contracts/modules/interest/BaseInterestERC20.sol
@@ -1,6 +1,7 @@
 pragma solidity 0.7.5;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
 import "../../../interfaces/IInterestReceiver.sol";
 import "../../../interfaces/IInterestImplementation.sol";
@@ -10,6 +11,8 @@ import "../../../interfaces/IInterestImplementation.sol";
  * @dev This contract contains common logic for investing ERC20 tokens into different interest-earning protocols.
  */
 abstract contract BaseInterestERC20 is IInterestImplementation {
+    using SafeERC20 for IERC20;
+
     /**
      * @dev Ensures that caller is an EOA.
      * Functions with such modifier cannot be called from other contract (as well as from GSN-like approaches)
@@ -35,7 +38,7 @@ abstract contract BaseInterestERC20 is IInterestImplementation {
     ) internal {
         require(_receiver != address(0));
 
-        IERC20(_token).transfer(_receiver, _amount);
+        IERC20(_token).safeTransfer(_receiver, _amount);
 
         if (Address.isContract(_receiver)) {
             IInterestReceiver(_receiver).onInterestReceived(_token);

--- a/contracts/upgradeable_contracts/modules/interest/CompoundInterestERC20.sol
+++ b/contracts/upgradeable_contracts/modules/interest/CompoundInterestERC20.sol
@@ -14,6 +14,8 @@ import "./BaseInterestERC20.sol";
  */
 contract CompoundInterestERC20 is BaseInterestERC20, MediatorOwnableModule {
     using SafeMath for uint256;
+    using SafeERC20 for IERC20;
+    using SafeERC20 for ICToken;
 
     uint256 internal constant SUCCESS = 0;
 
@@ -141,7 +143,7 @@ contract CompoundInterestERC20 is BaseInterestERC20, MediatorOwnableModule {
         uint256 invested = params.investedAmount;
         uint256 redeemed = _safeWithdraw(_token, _amount > invested ? invested : _amount);
         params.investedAmount = redeemed > invested ? 0 : invested - redeemed;
-        IERC20(_token).transfer(mediator, redeemed);
+        IERC20(_token).safeTransfer(mediator, redeemed);
     }
 
     /**
@@ -210,11 +212,11 @@ contract CompoundInterestERC20 is BaseInterestERC20, MediatorOwnableModule {
             cTokenBalance = 0;
         } else {
             // transfer cTokens as-is, if redeem has failed
-            cToken.transfer(mediator, cTokenBalance);
+            cToken.safeTransfer(mediator, cTokenBalance);
         }
 
         uint256 balance = IERC20(_token).balanceOf(address(this));
-        IERC20(_token).transfer(mediator, balance);
+        IERC20(_token).safeTransfer(mediator, balance);
         IERC20(_token).approve(address(cToken), 0);
 
         emit ForceDisable(_token, balance, cTokenBalance, params.investedAmount);


### PR DESCRIPTION
Both the Compound and AAVE platforms can work with non-standard ERC20 tokens. However, the `CompoundInterestERC20` and `AAVEInterestERC20` do not use `SafeERC20` functions for transfers and approvals of the tokens. Hence, they will fail to handle such tokens.
