### PR TITLE
Use SafeERC20.safeApprove

### DIFF
--- a/contracts/interfaces/ILegacyERC20.sol
+++ b/contracts/interfaces/ILegacyERC20.sol
@@ -1,0 +1,5 @@
+pragma solidity 0.7.5;
+
+interface ILegacyERC20 {
+    function approve(address spender, uint256 amount) external; // returns (bool);
+}


### PR DESCRIPTION
- `claimAaveAndPay` doesn't have a `onlyEOA` modifier
- `SafeERC20` is used for transfers but not for approvals, hence interest on USDT would fail.