### PR TITLE
Remove quote sign from the example

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -58,5 +58,5 @@ FOREIGN_ERC677_TOKEN_IMAGE=0x
 FOREIGN_TOKEN_FACTORY=0x
 
 # Suffixes appended to the token names on the bridged side
-HOME_TOKEN_NAME_SUFFIX=" on xDai"
-FOREIGN_TOKEN_NAME_SUFFIX=" on Mainnet"
+HOME_TOKEN_NAME_SUFFIX= on xDai
+FOREIGN_TOKEN_NAME_SUFFIX= on Mainnet

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -138,11 +138,11 @@ FOREIGN_TOKEN_FACTORY=
 
 # suffix used for token names for tokens bridged from Foreign to Home
 # usually you might want it to start with a space character
-HOME_TOKEN_NAME_SUFFIX=""
+HOME_TOKEN_NAME_SUFFIX=from XXX
 
 # suffix used for token names for tokens bridged from Home to Foreign
 # usually you might want it to start with a space character
-FOREIGN_TOKEN_NAME_SUFFIX=""
+FOREIGN_TOKEN_NAME_SUFFIX=from YYY
 
 # The api url of an explorer to verify all the deployed contracts in Home network. Supported explorers: Blockscout, etherscan
 #HOME_EXPLORER_URL=https://blockscout.com/poa/core/api

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -138,11 +138,11 @@ FOREIGN_TOKEN_FACTORY=
 
 # suffix used for token names for tokens bridged from Foreign to Home
 # usually you might want it to start with a space character
-HOME_TOKEN_NAME_SUFFIX=from XXX
+HOME_TOKEN_NAME_SUFFIX= from XXX
 
 # suffix used for token names for tokens bridged from Home to Foreign
 # usually you might want it to start with a space character
-FOREIGN_TOKEN_NAME_SUFFIX=from YYY
+FOREIGN_TOKEN_NAME_SUFFIX= from YYY
 
 # The api url of an explorer to verify all the deployed contracts in Home network. Supported explorers: Blockscout, etherscan
 #HOME_EXPLORER_URL=https://blockscout.com/poa/core/api


### PR DESCRIPTION
Usage of the quote sign in the deployment configuration file could lead to undesirable name of tokens like `Token name" on XXX"`