### PR TITLE
wrapAndRelayTokens AND CALL

### DIFF
--- a/contracts/helpers/WETHOmnibridgeRouter.sol
+++ b/contracts/helpers/WETHOmnibridgeRouter.sol
@@ -52,6 +52,18 @@ contract WETHOmnibridgeRouter is OwnableModule, Claimable {
         bridge.relayTokens(address(WETH), _receiver, msg.value);
     }
 
+
+    /**
+    * @dev Wraps native assets and relays wrapped ERC20 tokens to the other chain.
+    * It also calls receiver on other side with the _data provided.
+    * @param _receiver bridged assets receiver on the other side of the bridge.
+    * @param _data data for the call of receiver on other side.
+    */
+    function wrapAndRelayTokens(address _receiver, bytes memory _data) public payable {
+        WETH.deposit{ value: msg.value }();
+        bridge.relayTokensAndCall(address(WETH), _receiver, msg.value, _data);
+    }
+
     /**
      * @dev Bridged callback function used for unwrapping received tokens.
      * Can only be called by the associated Omnibridge contract.

--- a/contracts/interfaces/IOmnibridge.sol
+++ b/contracts/interfaces/IOmnibridge.sol
@@ -6,4 +6,11 @@ interface IOmnibridge {
         address _receiver,
         uint256 _value
     ) external;
+
+    function relayTokensAndCall(
+        address token,
+        address _receiver,
+        uint256 _value,
+        bytes memory _data
+    ) external;
 }


### PR DESCRIPTION
This PR upgrades WETHOmnibridgeRouter contract to allow call of a recipient on other side. Implemented by overloading `wrapAndRelayTokens` with one more arg (data for the call)