### PR TITLE
deps reorder

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "envalid": "^6.0.2",
     "promise-retry": "^2.0.1",
     "querystring": "^0.2.0",
+    "@openzeppelin/contracts": "3.2.2-solc-0.7",
     "web3": "1.3.1"
   },
   "devDependencies": {
-    "@openzeppelin/contracts": "3.2.2-solc-0.7",
     "@truffle/contract": "^4.3.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",


### PR DESCRIPTION
@openzeppelin/contracts dependency moved from devDependencies to dependencies section so it can be installed and used as npm package. I also recommend defining `files` section in package.json to export only necessary files